### PR TITLE
fix: switch-case stmt for built-in functions

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -78,8 +78,6 @@ func (c cleanCmd) Sweep(ctx context.Context, targetFilePath string) error {
 		return err
 	}
 
-	ast.Print(fset, c.astFile)
-
 	if err := c.removeDlFromAst(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Overview
Current codes doesn't consider built-in function because it's an impossible case like below.

```go
func main() {
      panic(dl.Info("hoge")) // As the dl.Info returns (int, error), built-in function doesn't allow this case.
}
```

But, `dl` shows some error messages like below when there's built-in function.

```bash
$ dl clean .
remove dl from main.go
failed findDlImportInImportSpec: fun is not *ast.SelectorExpr: panic\nPlease report this bug to https://github.com/task4233/dl/issues/new/choose if possible🙏\n[main b63f4d5] feat
 1 file changed, 21 insertions(+), 2 deletions(-)
```

Thus, `dl` ignores built-in function calling.